### PR TITLE
Interface ip and backoff retry

### DIFF
--- a/gandi-ldns.py
+++ b/gandi-ldns.py
@@ -81,8 +81,8 @@ def read_config(config_path):
 
 
 def main():
-    SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.join(SCRIPT_DIR, "config.txt")
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.join(script_dir, "config.txt")
     config = read_config(path)
     if not config:
         sys.exit("please fill in the 'config.txt' file")

--- a/gandi-ldns.py
+++ b/gandi-ldns.py
@@ -111,7 +111,6 @@ def main():
                 " WAN IP:",
                 current_ip,
             )
-            sys.exit()
             change_zone_ip(config[section], current_ip)
             zone_ip = get_zone_ip(config[section])
             print("DNS A record update complete - set to: ", zone_ip)


### PR DESCRIPTION
##  Changes
1. use requests sessions with max_retries for 3 attempts using exponential backup
2. use ipaddress module to verify IP returned by ipify API
3. make output a little more consistent

## References
- [Advanced usage of Python requests - timeouts, retries, hooks](https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/)
- [Requests: HTTP for Humans™ — Requests documentation](https://requests.readthedocs.io/en/latest/)
- [ipaddress — IPv4/IPv6 manipulation library — Python documentation](https://docs.python.org/3/library/ipaddress.html)